### PR TITLE
Fix mistake in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ module.exports = (eleventyConfig) => {
 Now you can use the `readingTime` filter in your Nunjuck templates:
 
 ```html
-<span>About {{ someTextContent | readingTime } reading time}</span>
+<span>About {{ someTextContent | readingTime }} reading time</span>
 ```
 
 prints


### PR DESCRIPTION
The nunjucks example had the closing curly bracket in the wrong place. 